### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CI: true
   TURBO_TELEMETRY_DISABLED: 1


### PR DESCRIPTION
Potential fix for [https://github.com/yunarch/config-web/security/code-scanning/2](https://github.com/yunarch/config-web/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow only performs linting and testing, it requires minimal permissions. We will set `contents: read` as the only permission, which is sufficient for checking out the repository and running the CI tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
