### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,5 +1,8 @@
 name: Secrets scanning
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/yunarch/config-web/security/code-scanning/1](https://github.com/yunarch/config-web/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves checking out the repository and scanning for secrets, it only requires `contents: read` permissions. This ensures that the `GITHUB_TOKEN` has the minimal access necessary to perform the task, adhering to the principle of least privilege.

The `permissions` block will be added at the root level of the workflow, so it applies to all jobs in the workflow. This avoids redundancy and ensures consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
