### PR TITLE
fix: correct separator in execution log output

### DIFF
--- a/src/cli/bun-run-all/utils.ts
+++ b/src/cli/bun-run-all/utils.ts
@@ -30,7 +30,7 @@ function reportExecutionLog({
   console.log('');
   console.log(
     styleText(['white', 'bold'], 'Tasks:\t'),
-    `${failedTasksText}${failedTasksText && successTasksText ? '/' : ''}${successTasksText}`,
+    `${failedTasksText}${failedTasksText && successTasksText ? '|' : ''}${successTasksText}`,
     styleText('gray', `-- ${tasks} total`)
   );
   console.log(


### PR DESCRIPTION
## Description

Add the correct separator.